### PR TITLE
iPhoneでTwitterタイムラインが横にはみ出てしまう問題の修正

### DIFF
--- a/components/TwitterTimeLine.vue
+++ b/components/TwitterTimeLine.vue
@@ -19,3 +19,10 @@ import { Component, Vue } from 'nuxt-property-decorator';
 @Component
 export default class Biography extends Vue {}
 </script>
+<style>
+@media screen and (max-width: 750px) {
+  iframe.twitter-timeline {
+    width: 724px !important;
+  }
+}
+</style>

--- a/components/TwitterTimeLine.vue
+++ b/components/TwitterTimeLine.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="twitter-wrapper">
     <a
       class="twitter-timeline"
       data-height="630"
@@ -23,6 +23,10 @@ export default class Biography extends Vue {}
 @media screen and (max-width: 750px) {
   iframe.twitter-timeline {
     width: 724px !important;
+  }
+
+  .twitter-wrapper {
+    padding: 4px 4px 0;
   }
 }
 </style>


### PR DESCRIPTION
現在の状態だと
![IMG_2639](https://user-images.githubusercontent.com/1955233/67227928-2fb02480-f473-11e9-914e-2f001ce5a085.PNG)
このようにタイムラインが横に長くなってしまっている（iPhone 8環境でwidth: 1152px）。

今回の修正で
![IMG_2638](https://user-images.githubusercontent.com/1955233/67227927-2f178e00-f473-11e9-9fa7-5c9043ad46fc.PNG)
上記のようにカード領域に収まるようになった。

メディアクエリで今回対応を行ったため、タイムラインの表示箇所のレイアウト変更などを行う場合、max-widthなどの値を変える必要がある。

またカード内にタイムラインを収めた結果、ツイートのセパレータの線がカードのアウトラインに被ってしまうため、paddingで調整を行った。
